### PR TITLE
Fix PDF generation and empty content handling

### DIFF
--- a/client/lib/pdf.ts
+++ b/client/lib/pdf.ts
@@ -32,77 +32,76 @@ export async function generateExamStylePdf(params: {
     }
   } catch {}
 
-  // Build an offscreen container that includes an optional institute header (logo + name) and the formatted body
+  // Always render into a neutral offscreen container to ensure readable colors (black text on white background)
   let wrapper: HTMLDivElement | null = null;
-  let container: HTMLElement | null = document.querySelector(
-    ".paper-view .paper-body",
-  );
+  let container: HTMLElement | null = null;
   let cleanup: (() => void) | null = null;
 
-  if (!container) {
-    wrapper = document.createElement("div");
-    wrapper.style.position = "fixed";
-    wrapper.style.left = "-99999px";
-    wrapper.style.top = "0";
-    wrapper.style.width = "794px"; // approx A4 width in px at 96dpi
-    wrapper.className = "paper-view";
+  wrapper = document.createElement("div");
+  wrapper.style.position = "fixed";
+  wrapper.style.left = "-99999px";
+  wrapper.style.top = "0";
+  wrapper.style.width = "794px"; // approx A4 width in px at 96dpi
+  wrapper.style.background = "#ffffff";
+  wrapper.className = "paper-view";
 
-    const inner = document.createElement("div");
-    inner.className =
-      "paper-body prose prose-invert prose-lg leading-relaxed max-w-none break-words";
+  const inner = document.createElement("div");
+  inner.className =
+    "paper-body prose prose-lg leading-relaxed max-w-none break-words";
+  inner.style.color = "#000000";
 
-    // Optional header: institute logo + name (no extra titles like MCQs/QnA/Exam)
-    if (instituteHeader?.instituteName || instituteHeader?.instituteLogo) {
-      const header = document.createElement("div");
-      header.style.display = "flex";
-      header.style.alignItems = "center";
-      header.style.gap = "12px";
-      header.style.borderBottom = "1px solid #E5E7EB"; // neutral border
-      header.style.padding = "6px 0 12px 0";
+  // Optional header: institute logo + name (no extra titles like MCQs/QnA/Exam)
+  if (instituteHeader?.instituteName || instituteHeader?.instituteLogo) {
+    const header = document.createElement("div");
+    header.style.display = "flex";
+    header.style.alignItems = "center";
+    header.style.gap = "12px";
+    header.style.borderBottom = "1px solid #E5E7EB"; // neutral border
+    header.style.padding = "6px 0 12px 0";
 
-      if (instituteHeader?.instituteLogo) {
-        const img = document.createElement("img");
-        img.src = instituteHeader.instituteLogo;
-        img.alt = "Institute Logo";
-        img.style.width = "56px";
-        img.style.height = "56px";
-        img.style.objectFit = "contain";
-        img.style.borderRadius = "6px";
-        img.crossOrigin = "anonymous";
-        header.appendChild(img);
-      }
-
-      if (instituteHeader?.instituteName) {
-        const name = document.createElement("div");
-        name.style.fontWeight = "800";
-        name.style.fontSize = "18px";
-        name.style.lineHeight = "1.2";
-        name.textContent = String(instituteHeader.instituteName || "");
-        header.appendChild(name);
-      }
-
-      inner.appendChild(header);
+    if (instituteHeader?.instituteLogo) {
+      const img = document.createElement("img");
+      img.src = instituteHeader.instituteLogo;
+      img.alt = "Institute Logo";
+      img.style.width = "56px";
+      img.style.height = "56px";
+      img.style.objectFit = "contain";
+      img.style.borderRadius = "6px";
+      img.crossOrigin = "anonymous";
+      header.appendChild(img);
     }
 
-    const bodyEl = document.createElement("div");
-    try {
-      const fmt = await import("@/lib/format");
-      bodyEl.innerHTML = fmt.formatResultHtml(body || "");
-    } catch {
-      bodyEl.textContent = body || "";
+    if (instituteHeader?.instituteName) {
+      const name = document.createElement("div");
+      name.style.fontWeight = "800";
+      name.style.fontSize = "18px";
+      name.style.lineHeight = "1.2";
+      name.style.color = "#000000";
+      name.textContent = String(instituteHeader.instituteName || "");
+      header.appendChild(name);
     }
 
-    inner.appendChild(bodyEl);
-    wrapper.appendChild(inner);
-    document.body.appendChild(wrapper);
-    container = inner;
-    cleanup = () => {
-      try {
-        if (wrapper && wrapper.parentNode)
-          wrapper.parentNode.removeChild(wrapper);
-      } catch {}
-    };
+    inner.appendChild(header);
   }
+
+  const bodyEl = document.createElement("div");
+  bodyEl.style.color = "#000000";
+  try {
+    const fmt = await import("@/lib/format");
+    bodyEl.innerHTML = fmt.formatResultHtml(body || "");
+  } catch {
+    bodyEl.textContent = body || "";
+  }
+
+  inner.appendChild(bodyEl);
+  wrapper.appendChild(inner);
+  document.body.appendChild(wrapper);
+  container = inner;
+  cleanup = () => {
+    try {
+      if (wrapper && wrapper.parentNode) wrapper.parentNode.removeChild(wrapper);
+    } catch {}
+  };
 
   const rect = container.getBoundingClientRect();
   const width = Math.max(700, Math.ceil(rect.width));

--- a/client/lib/pdf.ts
+++ b/client/lib/pdf.ts
@@ -99,7 +99,8 @@ export async function generateExamStylePdf(params: {
   container = inner;
   cleanup = () => {
     try {
-      if (wrapper && wrapper.parentNode) wrapper.parentNode.removeChild(wrapper);
+      if (wrapper && wrapper.parentNode)
+        wrapper.parentNode.removeChild(wrapper);
     } catch {}
   };
 

--- a/client/pages/MCQs.tsx
+++ b/client/pages/MCQs.tsx
@@ -435,14 +435,20 @@ Use concise, exam-style wording suitable for classroom tests.`;
         const text =
           typeof json === "string"
             ? json
-            : (json?.questions ?? json?.result ?? json?.message ?? JSON.stringify(json));
+            : (json?.questions ??
+              json?.result ??
+              json?.message ??
+              JSON.stringify(json));
         const finalText = String(text || "").trim();
         setResult(finalText);
         setCached(cacheKey, finalText);
         setLatest("mcqs", finalText, uid);
         if (!finalText) {
           console.warn("MCQ generation: empty result from API (json)");
-          toast({ title: "No content", description: "The generation service returned no content." });
+          toast({
+            title: "No content",
+            description: "The generation service returned no content.",
+          });
         }
       } else {
         const text = String((await attempt.text()) || "").trim();
@@ -451,7 +457,10 @@ Use concise, exam-style wording suitable for classroom tests.`;
         setLatest("mcqs", text, uid);
         if (!text) {
           console.warn("MCQ generation: empty result from API (text)");
-          toast({ title: "No content", description: "The generation service returned no content." });
+          toast({
+            title: "No content",
+            description: "The generation service returned no content.",
+          });
         }
       }
     } finally {

--- a/client/pages/MCQs.tsx
+++ b/client/pages/MCQs.tsx
@@ -435,19 +435,24 @@ Use concise, exam-style wording suitable for classroom tests.`;
         const text =
           typeof json === "string"
             ? json
-            : (json?.questions ??
-              json?.result ??
-              json?.message ??
-              JSON.stringify(json));
-        const finalText = String(text);
+            : (json?.questions ?? json?.result ?? json?.message ?? JSON.stringify(json));
+        const finalText = String(text || "").trim();
         setResult(finalText);
         setCached(cacheKey, finalText);
         setLatest("mcqs", finalText, uid);
+        if (!finalText) {
+          console.warn("MCQ generation: empty result from API (json)");
+          toast({ title: "No content", description: "The generation service returned no content." });
+        }
       } else {
-        const text = await attempt.text();
+        const text = String((await attempt.text()) || "").trim();
         setResult(text);
         setCached(cacheKey, text);
         setLatest("mcqs", text, uid);
+        if (!text) {
+          console.warn("MCQ generation: empty result from API (text)");
+          toast({ title: "No content", description: "The generation service returned no content." });
+        }
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Purpose

The user reported issues with paper generation where:
- Papers were not displaying after downloading/generation completed
- The system showed a "generate" button again after loading but no paper content was visible

## Code changes

**PDF Generation (`client/lib/pdf.ts`)**:
- Always create a neutral offscreen container with white background and black text for consistent PDF rendering
- Removed conditional logic that could skip proper container creation
- Added explicit color styling (`#000000` text, `#ffffff` background) to ensure readable PDF output
- Simplified container creation flow to always use the offscreen approach

**MCQ Generation (`client/pages/MCQs.tsx`)**:
- Added validation for empty/null API responses with `.trim()` checks
- Implemented user-friendly error notifications when generation returns no content
- Added console warnings for debugging empty response scenarios
- Enhanced error handling for both JSON and text response formatsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b7eadbeb2c2b421c93a1c928593d40bf/cosmos-haven)

👀 [Preview Link](https://b7eadbeb2c2b421c93a1c928593d40bf-cosmos-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b7eadbeb2c2b421c93a1c928593d40bf</projectId>-->
<!--<branchName>cosmos-haven</branchName>-->